### PR TITLE
Add Docker && a default .homebase.yml

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,2 @@
+node_modules
+npm-debug.log

--- a/.homebase.yml
+++ b/.homebase.yml
@@ -1,0 +1,44 @@
+directory: ~/.homebase # where your data will be stored
+httpMirror: true       # enables http mirrors of the dats
+ports:
+  http: 80             # HTTP port for redirects or non-SSL serving
+  https: 443           # HTTPS port for serving mirrored content & DNS data
+#letsencrypt:           # set to false to disable lets-encrypt
+#  email: bob@foo.com   # you must provide your email to LE for admin
+#  agreeTos: true       # you must agree to the LE terms (set to true)
+dashboard:             # set to false to disable
+  port: 8089           # port for accessing the metrics dashboard
+
+# enable publishing to Homebase from Beaker & Dat-CLI
+webapi:                # set to false to disable
+  username: robert     # the username for publishing from Beaker/Dat-CLI
+  password: hunter2    # the password for publishing from Beaker/Dat-CLI
+#  domain: foo.bar
+
+# enter your pinned dats here
+dats: []               # `[]` for empty list. Remove it `[]` if you have dats listed
+#- url: dat://1f968afe867f06b0d344c11efc23591c7f8c5fb3b4ac938d6000f330f6ee2a03/
+#  domains:
+#  - mysite.com
+#  - my-site.com
+#- url: 868d6000f330f6967f06b3ee2a03811efc23591afe0d344cc7f8c5fb3b4ac91f
+#  domain:
+#  - othersite.com
+
+# enter any proxied routes here
+proxies: []            # `[]` for empty list. Remove it `[]` if you have proxies listed
+#- from: myproxy.com
+#  to: https://mysite.com/
+#- from: foo.proxy.edu
+#  to: http://localhost:8080/
+#- from: best-proxy-ever
+#  to: http://127.0.0.1:123/
+
+# enter any redirect routes here
+redirects: []          # `[]` for empty list. Remove it `[]` if you have proxies listed
+#- from: myredirect.com
+#  to: https://mysite.com/
+#- from: foo.redirect.edu
+#  to: http://localhost:8080/
+#- from: best-redirect-ever
+#  to: http://127.0.0.1:123/

--- a/.homebase.yml
+++ b/.homebase.yml
@@ -6,8 +6,10 @@ ports:
 #letsencrypt:           # set to false to disable lets-encrypt
 #  email: bob@foo.com   # you must provide your email to LE for admin
 #  agreeTos: true       # you must agree to the LE terms (set to true)
-dashboard:             # set to false to disable
-  port: 8089           # port for accessing the metrics dashboard
+
+# Note: exposes a web-page that's available *without* authentication and has your dats' urls on it.
+#dashboard:             # set to false to disable
+#  port: 8089           # port for accessing the metrics dashboard
 
 # enable publishing to Homebase from Beaker & Dat-CLI
 webapi:                # set to false to disable

--- a/Dockerfile
+++ b/Dockerfile
@@ -16,6 +16,11 @@ COPY . .
 
 COPY .homebase.yml /root/.homebase.yml
 
+# From Node's Best Practices
+# See: https://github.com/nodejs/docker-node/blob/master/docs/BestPractices.md#environment-variables
+# Note: Only this is applied from the practices.
+ENV NODE_ENV production
+
 # Note: you still need to supply -p 80:80 -p 443:443 -p 3282:3282 -p 8089:8089
 # If you have Beaker opened, you may want to change the 3282 port. E.g., to run with -p 9999:3282
 EXPOSE 80 443 3282 8089

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,12 @@
 # Credits: https://nodejs.org/en/docs/guides/nodejs-docker-webapp/
 FROM node:8.12.0-alpine
 
+# Credits: https://github.com/nodejs/docker-node/issues/282#issuecomment-358907790
+RUN apk --no-cache --virtual build-dependencies add \
+    python \
+    make \
+    g++
+
 # Create app directory
 WORKDIR /usr/src/app
 
@@ -11,6 +17,9 @@ COPY package*.json ./
 
 # If you are building your code for production
 RUN npm install --only=production
+
+# Credits: https://github.com/nodejs/docker-node/issues/282#issuecomment-358907790
+RUN apk del build-dependencies
 
 COPY . .
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,5 @@
 # Credits: https://nodejs.org/en/docs/guides/nodejs-docker-webapp/
-
-FROM node
+FROM node:8.12.0-alpine
 
 # Create app directory
 WORKDIR /usr/src/app

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,11 +1,7 @@
 # Credits: https://nodejs.org/en/docs/guides/nodejs-docker-webapp/
-FROM node:8.12.0-alpine
+FROM node:8.12.0-jessie
 
-# Credits: https://github.com/nodejs/docker-node/issues/282#issuecomment-358907790
-RUN apk --no-cache --virtual build-dependencies add \
-    python \
-    make \
-    g++
+RUN apt-get update && apt-get install -y libtool m4 automake libcap2-bin build-essential
 
 # Create app directory
 WORKDIR /usr/src/app
@@ -17,9 +13,7 @@ COPY package*.json ./
 
 # If you are building your code for production
 RUN npm install --only=production
-
-# Credits: https://github.com/nodejs/docker-node/issues/282#issuecomment-358907790
-RUN apk del build-dependencies
+RUN npm install pm2 -g
 
 COPY . .
 
@@ -34,4 +28,4 @@ ENV NODE_ENV production
 # If you have Beaker opened, you may want to change the 3282 port. E.g., to run with -p 9999:3282
 EXPOSE 80 443 3282 8089
 
-CMD [ "npm", "start" ]
+CMD [ "pm2-runtime", "npm", "--", "start" ]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,24 @@
+# Credits: https://nodejs.org/en/docs/guides/nodejs-docker-webapp/
+
+FROM node
+
+# Create app directory
+WORKDIR /usr/src/app
+
+# Install app dependencies
+# A wildcard is used to ensure both package.json AND package-lock.json are copied
+# where available (npm@5+)
+COPY package*.json ./
+
+# If you are building your code for production
+RUN npm install --only=production
+
+COPY . .
+
+COPY .homebase.yml /root/.homebase.yml
+
+# Note: you still need to supply -p 80:80 -p 443:443 -p 3282:3282 -p 8089:8089
+# If you have Beaker opened, you may want to change the 3282 port. E.g., to run with -p 9999:3282
+EXPOSE 80 443 3282 8089
+
+CMD [ "npm", "start" ]

--- a/README.md
+++ b/README.md
@@ -506,6 +506,28 @@ ports:
 
 You will need to add all domains to your Nginx/Apache config.
 
+### Example: running homebase in a docker container
+
+1. Install [Docker](http://docker.com/). If you're on Linux, remember to [configure Docker to start on boot](https://docs.docker.com/install/linux/linux-postinstall/). Don't know of the equivalent for other systems.
+
+2. Clone the project. Edit `.homebase.yml` according to your needs. Most importantly: **Change username and password**.  
+If you don't want to think of a username and a password, just use [this](https://stackoverflow.com/a/1349426/6690391) but **increase the length**.
+
+3. In the project root, run this command:
+
+```
+docker build -t homebase:latest . && docker run -d --name=homebase --restart=always -p 80:80 -p 443:443 -p 3282:3282 -p 8089:8089 homebase:latest
+```
+
+**Notes:**  
+1. Not an expert in Docker security or configuration.  
+2. if you have Beaker on the same machine, you may want to change the dat port `-p 3282:3282` to something like `-p 9999:3282`.  
+3. To debug the running container:
+   - Run `docker ps -a` to see the container running status.  
+   - Run `docker logs homebase` to see the logs (Note: don't expect much).
+   - Run `docker exec -it homebase sh` to get into a terminal. However, the container's base image is `alpine` and doesn't have many tools; you may want to change the first line in `Dockerfile` to `FROM node:8.2.10-jessie`
+4. Didn't think about how you'd install a newer version of homebase while keeping the old configuration and data.
+
 ## Troubleshooting
 
 ### Installing build dependencies

--- a/README.md
+++ b/README.md
@@ -524,8 +524,8 @@ docker build -t homebase:latest . && docker run -d --name=homebase --restart=alw
 2. if you have Beaker on the same machine, you may want to change the dat port `-p 3282:3282` to something like `-p 9999:3282`.  
 3. To debug the running container:
    - Run `docker ps -a` to see the container running status.  
-   - Run `docker logs homebase` to see the logs (Note: don't expect much).
-   - Run `docker exec -it homebase sh` to get into a terminal. However, the container's base image is `alpine` and doesn't have many tools; you may want to change the first line in `Dockerfile` to `FROM node:8.2.10-jessie`
+   - Run `docker logs homebase` to see the logs.
+   - Run `docker exec -it homebase sh` to get into a terminal.
 4. Didn't think about how you'd install a newer version of homebase while keeping the old configuration and data.
 
 ## Troubleshooting

--- a/README.md
+++ b/README.md
@@ -516,7 +516,7 @@ If you don't want to think of a username and a password, just use [this](https:/
 3. In the project root, run this command:
 
 ```
-docker build -t homebase:latest . && docker run -d --name=homebase --restart=always -p 80:80 -p 443:443 -p 3282:3282 -p 8089:8089 homebase:latest
+docker build -t homebase:latest . && docker run -d --name=homebase --restart=always -p 80:80 -p 443:443 -p 3282:3282 homebase:latest
 ```
 
 **Notes:**  


### PR DESCRIPTION
**Goal:** Setup Homebase through Docker.

**Summary of changes:**
- Added a `Dockerfile` and `.dockerignore` that assumes production settings, following [this article](https://nodejs.org/en/docs/guides/nodejs-docker-webapp/).
- Added a default `.homebase.yml` to be used in the `Dockerfile`.
- Added instructions in `README.md`.

**Notes:**
- I understand if you don't want to include Docker in order to not complicate things. I was setting things up for myself & documenting the steps anyway.
- Not a Docker expert and didn't necessarily setup things in the _best_ way possible.
- If one wants to include Prometheus and Grafana, they're on their own. I did make a setup with [Docker Compose](https://docs.docker.com/compose/) but got no data in the end. Didn't continue that path. If you want docker-compose setup, I think I may still have it.
- Needless to say, feel free to make any edits on anything.

**Disclaimer**: Perhaps my first serious PR; not sure of the etiquette.

**Update:** I'm currently having difficulties with homebase: connectivity problems and sudden shutdown. Not sure if the problem is with homebase or docker (probably it's docker). Prefer to keep this PR on hold till I resolve the problem.  
Should report back soon.