### PR TITLE
Handle percent-encoded paths in http mirror

### DIFF
--- a/lib/vhosts/dat.js
+++ b/lib/vhosts/dat.js
@@ -100,6 +100,8 @@ function createHttpMirror (vhostCfg) {
     var entry
     var isFolder = req.path.endsWith('/')
     const tryStat = async (path) => {
+      // handle percent-encoded paths
+      path = decodeURI(path)
       // abort if we've already found it
       if (entry) return
       // apply the web_root config


### PR DESCRIPTION
This is a fix that enables the HTTP Mirror to correctly return files that have percent-encoded paths.

Original Issue: https://github.com/beakerbrowser/homebase/issues/27