### PR TITLE
Update port setup url

### DIFF
--- a/lib/server.js
+++ b/lib/server.js
@@ -103,7 +103,7 @@ ${chalk.bold(`== Homebase ${packageJson.version} ==`)}
       console.error(chalk.red(`ERROR: Failed to bind to ${chalk.bold(`port ${err.port}`)} (EACCES)
 
 Make sure the ${chalk.bold(`port is not in use`)} and that you ${chalk.bold(`have permission`)} to use it.
-See ${chalk.underline(`https://github.com/beakerbrowser/homebase/tree/master#port-setup`)}`))
+See ${chalk.underline(`https://github.com/beakerbrowser/homebase/tree/master#port-setup-eacces-error`)}`))
       process.exit(1)
     }
     throw err


### PR DESCRIPTION
The old URL is defunct, so it just lead to the top of the README