### PR TITLE
First pass at disk quotas

### DIFF
--- a/.homebase.yml
+++ b/.homebase.yml
@@ -6,6 +6,7 @@ ports:
 #letsencrypt:           # set to false to disable lets-encrypt
 #  email: bob@foo.com   # you must provide your email to LE for admin
 #  agreeTos: true       # you must agree to the LE terms (set to true)
+diskQuota: 0            # disk quota in bytes, 100 MB = 100000000; 0 = no quota
 
 # Note: exposes a web-page that's available *without* authentication and has your dats' urls on it.
 #dashboard:             # set to false to disable

--- a/lib/config.js
+++ b/lib/config.js
@@ -27,6 +27,8 @@ const isDomain = require('is-domain-name')
 const isOrigin = require('is-http-url')
 const _flatten = require('lodash.flatten')
 const {ConfigError} = require('./errors')
+const getFolderSize = require('get-folder-size')
+const dat = require('./vhosts/dat')
 
 const DEFAULT_CONFIG_DIRECTORY = path.join(os.homedir(), '.homebase')
 const IS_DEBUG = (['debug', 'staging', 'test'].indexOf(process.env.NODE_ENV) !== -1)
@@ -47,10 +49,16 @@ class HomebaseConfig {
     // - can then be updated by APIs
     // - *may* be slightly massaged so long as it won't annoy users
     this.canonical = {}
+    this.diskUsage = null
+    this.estimatedDiskUsage = null
 
     if (configPath) {
       this.readFromFile(configPath)
     }
+
+    // align our estimated disk usage with real disk usage every 5 minutes
+    this.updateDiskUsage()
+    setInterval(this.updateDiskUsage.bind(this), 1000*60*5)
   }
 
   readFromFile (configPath = false) {
@@ -124,8 +132,45 @@ class HomebaseConfig {
     this.writeToFile()
   }
 
+  // calculate disk usage in hosting directory
+  updateDiskUsage() {
+    return new Promise(resolve => {
+      getFolderSize(this.directory, (err, size) => {
+        if (err) {
+          throw err
+        }
+        // - `size` is in bytes
+        // - when we fully parse the tree our "estimate" is exactly correct
+        // - this will drift over time as blocks come in
+        // - we keep a running estimate so we don't need to parse the full
+        //   storage folder on every block that is downloaded
+        this.diskUsage = size
+        this.estimatedDiskUsage = size
+
+        // if we are under quota, restart all dats
+        // is this the right place to do this?? config seems wrong but when we
+        // update the disk space seems right
+        console.log(this.diskUsage, this.diskQuota, this.diskUsage/this.diskQuota)
+        if (this.diskUsage < this.diskQuota) {
+          this.dats.forEach(datCfg => dat.start(datCfg, this))
+        }
+
+        resolve(this.diskUsage)
+      })
+    })
+  }
+
+  isBlockWithinQuota(block) {
+    this.estimatedDiskUsage = this.estimatedDiskUsage + block.length
+    return this.estimatedDiskUsage < this.diskQuota
+  }
+
   get directory () {
     return untildify(this.canonical.directory || DEFAULT_CONFIG_DIRECTORY)
+  }
+
+  get diskQuota () {
+    return this.canonical.diskQuota || 0
   }
 
   get httpMirror () {
@@ -323,6 +368,7 @@ function validate (config) {
 
   if ('directory' in config) check(typeof config.directory === 'string', 'directory must be a string, see https://github.com/beakerbrowser/homebase/tree/master#directory')
   if ('httpMirror' in config) check(typeof config.httpMirror === 'boolean', 'httpMirror must be true or false, see https://github.com/beakerbrowser/homebase/tree/master#httpmirror')
+  if ('diskQuota' in config) check(typeof config.diskQuota === 'number', 'diskQuota must be a number')
   if ('ports' in config) check(config.ports && typeof config.ports === 'object', 'ports must be an object containing .http and/or .https, see https://github.com/beakerbrowser/homebase/tree/master#ports')
   if ('ports' in config && 'http' in config.ports) check(typeof config.ports.http === 'number', 'ports.http must be a number, see https://github.com/beakerbrowser/homebase/tree/master#portshttp')
   if ('ports' in config && 'https' in config.ports) check(typeof config.ports.https === 'number', 'ports.https must be a number, see https://github.com/beakerbrowser/homebase/tree/master#portshttp')

--- a/lib/server.js
+++ b/lib/server.js
@@ -56,6 +56,7 @@ ${chalk.bold(`== Homebase ${packageJson.version} ==`)}
  ${BULLET} Lets Encrypt: ${config.letsencrypt ? ENABLED : DISABLED}
  ${BULLET} Dashboard:    ${config.dashboard ? ENABLED : DISABLED}
  ${BULLET} WebAPI:       ${config.webapi ? ENABLED : DISABLED} ${config.webapi ? config.webapi.domain : ''}
+ ${BULLET} User quota:   ${config.diskQuota} bytes
 `)
 
   // create server app

--- a/lib/vhosts/dat.js
+++ b/lib/vhosts/dat.js
@@ -24,6 +24,34 @@ module.exports.start = function (vhostCfg, config) {
       }
       dat.joinNetwork()
       activeDats[vhostCfg.id] = dat
+
+      // every time we download a new block of data, check to see if we
+      // would be over quota adding this whole block. The function also keeps
+      // a running estimate of our "new" quota without parsing the directory tree
+      let checkDiskQuota = (index, block) => {
+        let blockSize = block.length;
+        if (config.isBlockWithinQuota(block)) {
+          console.log('WE ARE NOT OVER QUOTA', config.estimatedDiskUsage, config.diskQuota)
+          // all good, do nothing
+        }
+        else {
+          console.log('WE ARE OVER QUOTA, STOPPING DAT')
+          // over quota, stop the dat
+          this.stop(vhostCfg)
+        }
+      }
+
+      checkDiskQuota(0, 0)
+
+      if (!dat.archive.content) {
+        dat.archive.on('content', () => {
+          dat.archive.content.on('download', checkDiskQuota)
+        })
+      }
+      else {
+        dat.archive.content.on('download', checkDiskQuota)
+      }
+
       metrics.trackDatStats(dat, vhostCfg)
     })
   }
@@ -58,6 +86,22 @@ module.exports.stop = function (vhostCfg) {
 
   // log
   console.log(`${chalk.bold(`Stopped serving`)} ${vhostCfg.url}`)
+}
+
+module.exports.getStats = function (key) {
+  return new Promise(resolve => {
+    // Download sparse dat to check the file stats
+    Dat('/tmp', {key, sparse: true}, function (err, dat) {
+      if (err) {
+        throw err
+      }
+      let stats = dat.trackStats()
+      dat.joinNetwork()
+      stats.once('update', () => {
+        resolve(dat.stats.get())
+      })
+    })
+  })
 }
 
 // internal methods

--- a/lib/webapi.js
+++ b/lib/webapi.js
@@ -2,6 +2,7 @@ const crypto = require('crypto')
 const express = require('express')
 const bodyParser = require('http-body-parser').express
 const {validateDatCfg, getDatKey} = require('./config')
+const dat = require('./vhosts/dat');
 
 var sessions = new Set()
 
@@ -62,7 +63,9 @@ module.exports.create = function (config) {
 
   server.get('/v1/accounts/account', validateSession, (req, res) => {
     res.json({
-      username: config.webapi.username
+      username: config.webapi.username,
+      diskUsage: config.diskUsage,
+      diskQuota: config.diskQuota
     })
   })
 
@@ -92,10 +95,22 @@ module.exports.create = function (config) {
       if (e.noRootDomain) message = `No root domain set for the web api (${e.value}).`
       return res.status(422).json({message})
     }
-
-    // add to config
-    config.addDat(datCfg)
-    res.status(200).end()
+    // make sure this dat is smaller than the remaining user quota
+    // get size of dat being requested to be pinned, from its metadata
+    dat.getStats(datCfg.url).then(stats => {
+      let datSize = stats.byteLength
+      // get size of the home folder (diskUsage)
+      config.updateDiskUsage().then(() => {
+        if (datSize < (config.diskQuota - config.diskUsage)) {
+          // add to config
+          config.addDat(datCfg)
+          res.status(200).end()
+        }
+        else {
+          res.status(403).json({message: `User is over quota: requested dat is ${datSize} bytes, user has ${config.diskQuota - config.diskUsage} bytes remaining.`})
+        }
+      });
+    })
   })
 
   server.post('/v1/dats/remove', validateSession, (req, res) => {

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
     "dat-node": "^3.5.9",
     "express": "^4.16.3",
     "figures": "^2.0.0",
+    "get-folder-size": "^2.0.1",
     "greenlock": "^2.3.11",
     "http-body-parser": "^1.1.9",
     "http-proxy": "^1.17.0",

--- a/test/webapi-test.js
+++ b/test/webapi-test.js
@@ -76,6 +76,8 @@ dats:
   })
   t.deepEqual(res.statusCode, 200)
   t.deepEqual(res.body.username, 'bob')
+  t.not(res.body.diskQuota, undefined)
+  t.not(res.body.diskUsed, undefined)
 
   // can list dats
   res = await server.req.get({


### PR DESCRIPTION
This is an attempt to implement the `diskQuota` and `diskUsage` features in [DEP-0003](https://www.datprotocol.com/deps/0003-http-pinning-service-api/#user-accounts-api). This is a draft implementation, and my first homebase contribution, so I'm sure there is a lot of room for improvement and it could use an extra set of eyes. There are a bunch of console logs in here which won't be in the final version, as well, but are included for the sake of debugging during development.

Basic features follow.

## Add a `diskQuota` variable to the config

There is now a `diskQuota` field in the config that accepts a quota in bytes. I couldn't find a library that parses "human" byte strings like "100MB" or "1GB" to a byte `Number`, and in fact [that might be an antipattern](https://github.com/avoidwork/filesize.js/issues/91) so I'm just sticking to raw bytes. Since the users of homebase are sysadmins of some flavor, I think this should be okay.

## Return `diskQuota` and `diskUsage` on GET account call

When you send GET `/v1/accounts/account`, you now get the quota and space used, per DEP-0003.

## Rejects a new pinning request if accepting the request would put the user over quota

On a call to `/v1/dats/add`, the sparse statistics for the dat are downloaded. This tells us how big the full dat is, and we do the math based on the existing `diskUsage` and return a 403 error and message, `User is over quota: requested dat is ${datSize} bytes, user has ${config.diskQuota - config.diskUsage} bytes remaining.`

## On downloading a chunk of a dat, check to see if we are over quota

On a `'download'` event, if the chunk being downloaded would put us over quota, we stop downloading this particular dat.

We keep a running `estimatedDiskUsage` that is occasionally synced to the "real" `diskUsage` so we don't have to parse the entire directory tree every time a chunk is downloaded from an active dat. `estimatedDiskUsage` is synchronized to the real value every five minutes and on startup.

## Re-allow all downloads if we go back under quota

When we check the real `diskUsage` every five minutes, if we are under quota, we restart all dats, which allows for downloads again. Currently this will restart all dats every five minutes. I'm not sure if this is a "free" operation for a dat that is currently already active. Maybe we should make `activeDats` available somehow and only restart dats that are not in that object?
