### PR TITLE
Modify cache-control in http(s) rehosting

### DIFF
--- a/lib/vhosts/dat.js
+++ b/lib/vhosts/dat.js
@@ -194,7 +194,7 @@ function createHttpMirror (vhostCfg) {
           'Content-Type': mimeType,
           'Content-Security-Policy': cspHeader,
           'Access-Control-Allow-Origin': '*',
-          'Cache-Control': 'public, max-age=31536000',
+          'Cache-Control': 'public, max-age=60, must-revalidate',
           'ETag': ETag
         })
 


### PR DESCRIPTION
Modifying the `Cache-Control` header to ensure the client has a _fresh_ copy of the resource being requested.

In the original code `max-age` was set to 3156000 seconds, 1 year. This would cause the response to be cached for up to a year, subject to cache space, before the cache would check against the server if the cached copy was still fresh.

Changing this to `max-age=60, must-revalidate` will mean that the response will used from cache for 1 minute. After a minute the client will revalidate using the etag, which is handled by https://github.com/beakerbrowser/homebase/blob/a8261341b5cf1927c72974717965b5839a2684df/lib/vhosts/dat.js#L181-L182 

This PR will close #36