### PR TITLE
Change docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Credits: https://nodejs.org/en/docs/guides/nodejs-docker-webapp/
-FROM node:8.12.0-jessie
+FROM node:8-stretch
 
 RUN apt-get update && apt-get install -y libtool m4 automake libcap2-bin build-essential
 


### PR DESCRIPTION
I've picked 8-stretch. Using version 8 (rather than 8.12) keeps the project more-easily up to date with node versions (and node is semver, I think), and using stretch allows it to actually build because the jessie images haven't been updated since debian moved jessie's packages onto the archive.