### PR TITLE
handle directory listing and redirect

### DIFF
--- a/lib/vhosts/hyperdrive.js
+++ b/lib/vhosts/hyperdrive.js
@@ -95,8 +95,7 @@ function createHttpMirror (vhostCfg) {
       res.end(code + ' ' + status)
     }
     const respondRedirect = (url) => {
-      res.status(200)
-      res.html(`<!doctype html><meta http-equiv="refresh" content="0; url=${url}">`)
+      res.redirect(url)
     }
     var cspHeader = ''
 
@@ -137,8 +136,18 @@ function createHttpMirror (vhostCfg) {
       }
 
       // directory listing
-      res.code(200)
-      return res.html(directoryListingPage(drive, filepath))
+      res.set({
+        'Content-Type': 'text/html',
+        'Content-Security-Policy': cspHeader,
+        'Allow-CSP-From': '*',
+        'Access-Control-Allow-Origin': '*',
+        'Cache-Control': 'no-cache'
+      })
+      if (req.method === 'HEAD') {
+        return res.status(204).end()
+      } else {
+        return res.status(200).end(await directoryListingPage(drive, filepath))
+      }
     }
 
     if (!entry) {


### PR DESCRIPTION
This PR fixes the issue with the use of `res.html()` in the redirect and directory listing.